### PR TITLE
Switch linux deploy to use tar.gz generator

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - linux-ci-tgz
 
 jobs:
   testing:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - main
-      - linux-ci-tgz
 
 jobs:
   testing:
@@ -76,4 +75,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: x64 Linux RTS
-          path: build/linux64-deploy/SAGE-*-Linux.zip
+          path: build/linux64-deploy/SAGE-*-Linux.tar.gz

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -160,6 +160,9 @@
       "displayName": "Linux Release Package",
       "configurePreset": "linux64-deploy",
       "inherits": "deploy",
+      "generators": [
+        "TGZ"
+      ],
       "description": "Package the linux deploy configuration"
     }
   ],


### PR DESCRIPTION
Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/29

The current behavior uses zip for linux, which breaks the Linux libs directory. This updates it to use .tar.gz instead just for Linux.