### PR TITLE
SDL3 Window improvements for resizing

### DIFF
--- a/GeneralsMD/Code/CompatLib/Source/wnd_compat.cpp
+++ b/GeneralsMD/Code/CompatLib/Source/wnd_compat.cpp
@@ -1,5 +1,6 @@
 #include "types_compat.h"
 #include "wnd_compat.h"
+#include <SDL3/SDL.h>
 
 DWORD GetWindowLong(HWND hWnd, int nIndex)
 {
@@ -8,7 +9,8 @@ DWORD GetWindowLong(HWND hWnd, int nIndex)
 
 void AdjustWindowRect(RECT *pRect, DWORD dwStyle, BOOL bMenu)
 {
-
+  // This is left blank, since the SDL3 window is always going to be the in-game resolution size
+  // Windows seems to need to take into account the decoration size, which SDL3 does not need to
 }
 
 BOOL ShowWindow(HWND hWnd, int nCmdShow)
@@ -18,7 +20,16 @@ BOOL ShowWindow(HWND hWnd, int nCmdShow)
 
 void SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int cx, int cy, UINT uFlags)
 {
+  SDL_Window *window = (SDL_Window *)hWnd;
+  if (!window) return;
 
+  if (!(uFlags & SWP_NOMOVE)) {
+    SDL_SetWindowPosition(window, X, Y);
+  }
+
+  if (!(uFlags & SWP_NOSIZE)) {
+    SDL_SetWindowSize(window, cx, cy);
+  }
 }
 
 void GetWindowRect(HWND hWnd, RECT *pRect)

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
@@ -117,13 +117,6 @@ void SDL3GameEngine::update( void )
 
 	}
 
-	int currentWidth = 0, currentHeight = 0;
-	SDL_GetWindowSize(TheSDL3Window, &currentWidth, &currentHeight);
-
-	if (currentWidth != TheGlobalData->m_xResolution || currentHeight != TheGlobalData->m_yResolution) {
-		SDL_SetWindowSize(TheSDL3Window, TheGlobalData->m_xResolution, TheGlobalData->m_yResolution);
-	}
-
 	// allow windows to perform regular windows maintenance stuff like msgs
 	serviceWindowsOS();
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
@@ -33,6 +33,7 @@
 #include "SDL3Device/GameClient/SDL3Mouse.h"
 #include "SDL3Device/GameClient/SDL3Keyboard.h"
 #include "Common/PerfTimer.h"
+#include "Common/GlobalData.h"
 
 #include "GameNetwork/LANAPICallbacks.h"
 
@@ -114,6 +115,13 @@ void SDL3GameEngine::update( void )
     AudioAffect aa = (AudioAffect)0x10;
 		TheAudio->setVolume(TheAudio->getVolume( aa ), aa );
 
+	}
+
+	int currentWidth = 0, currentHeight = 0;
+	SDL_GetWindowSize(TheSDL3Window, &currentWidth, &currentHeight);
+
+	if (currentWidth != TheGlobalData->m_xResolution || currentHeight != TheGlobalData->m_yResolution) {
+		SDL_SetWindowSize(TheSDL3Window, TheGlobalData->m_xResolution, TheGlobalData->m_yResolution);
 	}
 
 	// allow windows to perform regular windows maintenance stuff like msgs

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
@@ -33,7 +33,6 @@
 #include "SDL3Device/GameClient/SDL3Mouse.h"
 #include "SDL3Device/GameClient/SDL3Keyboard.h"
 #include "Common/PerfTimer.h"
-#include "Common/GlobalData.h"
 
 #include "GameNetwork/LANAPICallbacks.h"
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -923,7 +923,6 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 		_RenderDeviceNameTable[CurRenderDevice].Peek_Buffer(),_RenderDeviceDescriptionTable[CurRenderDevice].Get_Driver_Name(),
 		_RenderDeviceDescriptionTable[CurRenderDevice].Get_Driver_Version(),ResolutionWidth,ResolutionHeight,(IsWindowed ? 1 : 0)));
 
-#ifdef _WINDOWS
 	// PWG 4/13/2000 - changed so that if you say to resize the window it resizes
 	// regardless of whether its windowed or not as OpenGL resizes its self around
 	// the caption and edges of the window type you provide, so its important to 
@@ -961,7 +960,6 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 								 SWP_NOZORDER | SWP_NOMOVE);
 		}
 	}
-#endif
 	//must be either resetting existing device or creating a new one.
 	WWASSERT(reset_device || D3DDevice == NULL);
 	

--- a/GeneralsMD/Code/Main/SDL3Main.cpp
+++ b/GeneralsMD/Code/Main/SDL3Main.cpp
@@ -71,7 +71,7 @@ static Bool initializeAppWindows(Bool runWindowed)
   }
 
   SDL_Window *window =
-      SDL_CreateWindow("Command and Conquer Generals", startWidth, startHeight, SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
+      SDL_CreateWindow("Command and Conquer Generals", startWidth, startHeight, SDL_WINDOW_VULKAN);
   SDL_ShowWindow(window);
   // save our window handle for future use
   ApplicationHWnd = TheSDL3Window = window;


### PR DESCRIPTION
This adds a few new improvements to the SDL3 window.

For one, it disables the resizing of the window, since it does not automatically update the internal game engine's resolution.

The second part implements SetWindowPos inside wnd_compat to use SDL3 API to resize the window. I left AdjustWindowRect alone, because we shouldn't need to do any additional calculation on Linux, since the window size for SDL3 does not include the decoration, as far as I can tell.

I also turned off an if windows check, so that the window can resize on startup.

I was able to test this locally and it worked well, resizing to 1024x768 on startup, since that's what my INI had in it, and then I resized it using the in-game resolution to 800x600 and that worked great too.