### PR TITLE
Navigation input improvements

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
@@ -106,6 +106,14 @@ static KeyDefType ConvertSDLKey(SDL_Keycode keycode)
 			return KEY_RCTRL;
 		case SDLK_LSHIFT:
 			return KEY_LSHIFT;
+		case SDLK_UP:
+			return KEY_UP;
+		case SDLK_DOWN:
+			return KEY_DOWN;
+		case SDLK_LEFT:
+			return KEY_LEFT;
+		case SDLK_RIGHT:
+			return KEY_RIGHT;
 		default:
 			break;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -126,20 +126,25 @@ void SDL3Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		// ------------------------------------------------------------------------
 		case SDL_EVENT_MOUSE_BUTTON_DOWN:
 		{
-			// TODO: detect double click
+			MouseButtonState buttonState = MBS_Down;
+
+			if (mouseBtnEvent.clicks == 2) {
+				buttonState = MBS_DoubleClick;
+			}
+
 			if (mouseBtnEvent.button == SDL_BUTTON_LEFT)
 			{
-				result->leftState = MBS_Down;
+				result->leftState = buttonState;
 				result->leftFrame = frame;
 			}
 			else if (mouseBtnEvent.button == SDL_BUTTON_RIGHT)
 			{
-				result->rightState = MBS_Down;
+				result->rightState = buttonState;
 				result->rightFrame = frame;
 			}
 			else if (mouseBtnEvent.button == SDL_BUTTON_MIDDLE)
 			{
-				result->middleState = MBS_Down;
+				result->middleState = buttonState;
 				result->middleFrame = frame;
 			}
 			result->pos.x = mouseBtnEvent.x;

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -117,8 +117,8 @@ void SDL3Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 	result->leftFrame = result->middleFrame = result->rightFrame = 0;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
-	// Time is the same for all events
-	result->time = m_eventBuffer[ eventIndex ].common.timestamp;
+	// Time is the same for all events; from nanoseconds
+	result->time = m_eventBuffer[ eventIndex ].common.timestamp / 1000000;
 	
 	switch( type )
 	{

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Mouse.cpp
@@ -182,8 +182,8 @@ void SDL3Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		// ------------------------------------------------------------------------
 		case SDL_EVENT_MOUSE_WHEEL:
 		{	
-			// note the short cast here to keep signed information in tact
-			result->wheelPos =  mouseWheelEvent.y;
+			// Wheel delta to match to Windows behavior of the scroll wheel
+			result->wheelPos =  mouseWheelEvent.y * 120;
 			result->pos.x = mouseWheelEvent.mouse_x;
 			result->pos.y = mouseWheelEvent.mouse_y;
 			break;


### PR DESCRIPTION
Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/35

Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/34

I imagine there's other inputs still missing but this adds some nice ones:

- One is the arrow keys for moving the camera around the map
- Another one is the scroll wheel. This was handled by mimicking the delta values from Windows (https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel#parameters). SDL3's is just -1 or 1
- Adds double click support
- Support alt mouse mode, via fixing the timestamp units (sdl3 is in nanoseconds, so that was causing confusion)

With these changes, I'm able to zoom in and out, and move the camera around with the keyboard! As well, the alt mouse mode (which is mainly left click for select, right click for move/attack), and double clicking to select all units of a type seems to work great.