### PR TITLE
Skirmish ai fix

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -62,6 +62,8 @@ Bool CachedFileInputStream::open(AsciiString path)
 			file = NULL;
 		}
 		m_pos=0;
+	} else {
+		DEBUG_LOG(("CachedFileInputStream::open - file not found %s\n", path.str()));
 	}
 
 	if (CompressionManager::isDataCompressed(m_buffer, m_size) == 0)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -522,7 +522,7 @@ void SidesList::prepareForMP_or_Skirmish(void)
 		}
 	}
 	if (!gotScripts) {
-		AsciiString path = "data\\Scripts\\SkirmishScripts.scb";
+		AsciiString path = "Data\\Scripts\\SkirmishScripts.scb";
 		DEBUG_LOG(("Skirmish map using standard scripts\n"));
 		m_skirmishTeamrec.clear();
 		CachedFileInputStream theInputStream;
@@ -561,6 +561,9 @@ void SidesList::prepareForMP_or_Skirmish(void)
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {
 					static_readPlayerNames[i].clear();
 				}
+		} else {
+			// Falling in here is what causes the skirmish AI to fail
+			DEBUG_LOG(("ERROR - Unable to open skirmish scripts.\n"));
 		}
 
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -52,9 +52,16 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access /* = 0 */)
 		return NULL;
 	}
 
-	// Convert the filename to a std::filesystem::path and pass that
+	std::string fixedFilename(filename);
+
+#ifndef _WIN32
 	// Replace backslashes with forward slashes on unix
-	std::filesystem::path path(filename);
+	std::replace(fixedFilename.begin(), fixedFilename.end(), '\\', '/');
+#endif
+
+	// Convert the filename to a std::filesystem::path and pass that
+	// make_preferred does not convert from Windows to Linux (see https://en.cppreference.com/w/cpp/filesystem/path/make_preferred)
+	std::filesystem::path path(fixedFilename);
 	path = path.make_preferred();
 
 	if (access & File::WRITE) {


### PR DESCRIPTION
Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/42

This fixes a problem where the skirmish AI never actually started, so immediately after launching into a skirmish game, the AI was "defeated".

There were a few issues contributing to this:

For one, the path it was using to load the SkirmishScripts was wrong, in terms of the case sensitivity. Since the data directory is actually "Data". Some of the other areas like the MultiplayerScripts had the correct case already, so changing this from data to Data seemed reasonable.

This also failed basically silently so it was hard to tell where it was. I added a DEBUG_LOG so if it does in the future it'll be easier to find.

The other issue was make_preferred does not appear to convert Windows to Linux paths (it can the other way around)

See "On the other hand, POSIX does not use \ as a separator, because backslashes are valid filename characters — the Windows path on POSIX actually refers to a file with the name "a\\b\\c". For this reason the "separators" are not converted."

Because of this the \\ was not actually getting converted to /, and also caused loading problems, once the case problem was fixed.

Once all of this was resolved, I was able to create a skirmish game, and then I no longer see the errors that you can see in the issue I linked, as well I can see the AI actually doing something! If I put the UAV over in their side of the map, I can see it building, whereas before it was doing nothing and in a "defeated" state.