### PR TITLE
[WIP] Hack for some crashes on Linux

### DIFF
--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/texture.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/texture.cpp
@@ -125,7 +125,11 @@ TextureBaseClass::~TextureBaseClass(void)
 
 	if (D3DTexture) 
 	{
+#ifdef _WIN32
+		// Theory here is that DXVK or something else may be releasing this already?
+		// Releasing here on Linux (like on exiting the game, causes a crash)
 		D3DTexture->Release();
+#endif
 		D3DTexture = NULL;
 	}
 


### PR DESCRIPTION
Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/37

Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/32

Wanted to bring it up to help pinpointing where the problem is, even though this is hacky.

Exiting the game, as well as starting a campaign was crashing, in this code.

The thinking was maybe dxvk is already cleaning it up, or something similar is going on, as releasing here on Linux causes the segfault. Removing it lets you go and do both.

I'm not really sure where to go from here though

