### PR TITLE
Fix for movies not loading

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -90,12 +90,16 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access /* = 0 */)
 			{
 				pathFixedPart = p;
 			}
+			else if (std::filesystem::exists(pathFixed / p, ec))
+			{
+				pathFixedPart = p;
+			}
 			else
 			{
 				// Check if the subpath exists using case-insensitive comparison
-				for (auto& entry : std::filesystem::directory_iterator(pathCurrent, ec))
+				for (auto& entry : std::filesystem::directory_iterator(pathFixed, ec))
 				{
-					if (strcasecmp(entry.path().filename().string().c_str(), filename.string().c_str()) == 0)
+					if (strcasecmp(entry.path().filename().string().c_str(), p.string().c_str()) == 0)
 					{
 						pathFixedPart = entry.path().filename();
 						break;


### PR DESCRIPTION
Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/55

The logic to handle case sensitivity wasn't working for loading the intro videos and the campaign videos. The deep path seemed to confuse it. This helps by using the fixed path for the directory search. I was able to see the intro videos and the campaign start videos with this fix.