### PR TITLE
Allow exiting from the SDL3 Window

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -94,7 +94,7 @@
 
 
 
-#define dont_ALLOW_ALT_F4
+#define ALLOW_ALT_F4
 
 
 #if defined(_DEBUG) || defined(_INTERNAL)

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
@@ -174,6 +174,16 @@ void SDL3GameEngine::serviceWindowsOS( void )
 					keyboard->addSDLEvent(&event);
 				}
 				break;
+			case SDL_EVENT_QUIT:
+				if (TheGameEngine && !TheGameEngine->getQuitting())
+				{
+					//user is exiting without using the menus; code from WinMain
+
+					//This method didn't work in cinematics because we don't process messages.
+					//But it's the cleanest way to exit that's similar to using menus.
+					TheMessageStream->appendMessage(GameMessage::MSG_META_DEMO_INSTANT_QUIT);
+				}
+				break;
 			// default:
 			// 	SDL_PushEvent(&event);
 				break;


### PR DESCRIPTION
This adds two main changes, one is enabling a command for exiting (The alt+f4 def)

The other is adding processing of events for sdl when we receive a quit (like the user clicking the close button in the window).

This sends that signal, which will trigger the message. I was able to exit from the menu and a skirmish map this way cleanly. Makes it a bit easier to close while n the middle of a game if you want.