### PR TITLE
Move to SDLTextInput for better support on special characters

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3GameEngine.cpp
@@ -170,6 +170,7 @@ void SDL3GameEngine::serviceWindowsOS( void )
 			case SDL_EVENT_KEYBOARD_ADDED:
 			case SDL_EVENT_KEYBOARD_REMOVED:
 			case SDL_EVENT_KEYMAP_CHANGED:
+			case SDL_EVENT_TEXT_INPUT:
 				if(keyboard) {
 					keyboard->addSDLEvent(&event);
 				}

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3IMEManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/Common/SDL3IMEManager.cpp
@@ -2,6 +2,10 @@
 #include "GameClient/GameWindowManager.h"
 #include "GameClient/GameWindow.h"
 
+#include <SDL3/SDL.h>
+
+extern HWND ApplicationHWnd;
+
 class SDL3IMEManager : public IMEManagerInterface
 {
 public:
@@ -28,11 +32,17 @@ public:
 
   virtual void attach(GameWindow *window) override
   {
+    if(window == NULL) {
+      SDL_StopTextInput(reinterpret_cast<SDL_Window*>(ApplicationHWnd));
+    } else {
+      SDL_StartTextInput(reinterpret_cast<SDL_Window*>(ApplicationHWnd));
+    }
     m_window = window;
   }
   virtual void detatch(void) override
   {
     m_window = nullptr;
+    SDL_StopTextInput(reinterpret_cast<SDL_Window*>(ApplicationHWnd));
   }
   virtual void enable(void) override
   {

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
@@ -116,6 +116,10 @@ static KeyDefType ConvertSDLKey(SDL_Keycode keycode)
 			return KEY_LEFT;
 		case SDLK_RIGHT:
 			return KEY_RIGHT;
+		case SDLK_PERIOD:
+			return KEY_PERIOD;
+		case SDLK_PLUS:
+			return KEY_KPPLUS;
 		default:
 			break;
 	}
@@ -139,22 +143,19 @@ void SDL3Keyboard::getKey( KeyboardIO *key )
 	{
 		SDL_Event event = m_events.front();
 		m_events.erase(m_events.begin());
-		if(event.type == SDL_EVENT_KEY_DOWN)
+		if (TheIMEManager && TheIMEManager->getWindow() && event.type == SDL_EVENT_TEXT_INPUT)
+		{
+			const char* text = event.text.text;
+			for (int i = 0; text[i] != '\0'; ++i)
+			{
+				WideChar wchar = static_cast<WideChar>(text[i]);
+				TheWindowManager->winSendInputMsg(TheIMEManager->getWindow(), GWM_IME_CHAR, wchar, 0);
+			}
+		}
+		else if(event.type == SDL_EVENT_KEY_DOWN)
 		{
 			key->key = ConvertSDLKey(event.key.key);
 			key->state = KEY_STATE_DOWN;
-
-			if (TheIMEManager && TheIMEManager->getWindow())
-			{
-				SDL_Keycode sym = event.key.key;
-
-				// Only inject if it's a printable ASCII character
-				if (sym >= 32 && sym <= 126)
-				{
-					WideChar wchar = static_cast<WideChar>(sym);
-					TheWindowManager->winSendInputMsg(TheIMEManager->getWindow(), GWM_IME_CHAR, wchar, 0);
-				}
-			}
 		}
 		else if(event.type == SDL_EVENT_KEY_UP)
 		{

--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
@@ -145,6 +145,7 @@ void SDL3Keyboard::getKey( KeyboardIO *key )
 		m_events.erase(m_events.begin());
 		if (TheIMEManager && TheIMEManager->getWindow() && event.type == SDL_EVENT_TEXT_INPUT)
 		{
+			// Note that special characters may need additional keycode translation above.
 			const char* text = event.text.text;
 			for (int i = 0; text[i] != '\0'; ++i)
 			{


### PR DESCRIPTION
This moves the typing (like for the skirmish name, and eventually possibly multiplayer login) to use SDLTextInput. This also adds the turning it on and off based on the IME attaching.

This should be very similar to the way it used to work, but now  you can shift+keys, for things like @.