### PR TITLE
Skirmish username fix

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -70,6 +70,7 @@
 #include "WWDownload/Registry.h"
 
 #include "Common/CopyProtection.h"
+#include "GameNetwork/GameSpy/ThreadUtils.h"
 
 #ifdef _INTERNAL
 // for occasional debugging...
@@ -211,7 +212,7 @@ UnicodeString SkirmishPreferences::getUserName(void)
 		return ret;
 	}
 
-	ret = QuotedPrintableToUnicodeString(it->second);
+	ret.translate(it->second);
 	ret.trim();
 	if (ret.isEmpty())
 	{
@@ -356,7 +357,8 @@ Bool SkirmishPreferences::write(void)
 
 	(*this)["Map"] = TheSkirmishGameInfo->getMap();
 
-	(*this)["UserName"] = UnicodeStringToQuotedPrintable(TheSkirmishGameInfo->getConstSlot(0)->getName());
+	AsciiString username = WideCharStringToMultiByte(TheSkirmishGameInfo->getConstSlot(0)->getName().str()).c_str();
+	(*this)["UserName"] = username;
 
   setStartingCash( TheSkirmishGameInfo->getStartingCash() );
   setSuperweaponRestricted( TheSkirmishGameInfo->getSuperweaponRestriction() != 0 );


### PR DESCRIPTION
This adds a fix for an issue where the skirmish username was getting cut off to just "d" for example if the username was set to d10sfan. The Skirmish.ini was stopping after the 1st character. This happened with the saved username like when you came back to the skirmish screen after completing a map

The first change uses a different way to store and retrieve the username, similar to other parts of the code. The second is to help avoid an issue where sometimes the typing would introduce garbage characters, this should improve that behavior.