### PR TITLE
Scale mouse coordinates based on window res and internal res

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/SDL3Device/GameClient/SDL3Mouse.h
@@ -90,6 +90,8 @@ protected:
   /// get the next event available in the buffer
   virtual UnsignedByte getMouseEvent(MouseIO *result, Bool flush);
 
+  static void scaleMouseCoordinates(int rawX, int rawY, Uint32 windowID, int& scaledX, int& scaledY);
+
   /// translate a win32 mouse event to our own info
   void translateEvent(UnsignedInt eventIndex, MouseIO *result);
 


### PR DESCRIPTION
Closes https://github.com/Fighter19/CnC_Generals_Zero_Hour/issues/58

This is mainly helpful for full screen, where sdl is making the window the display size, and we aren't trying to set the display mode (which we really shouldn't on linux). So this scales the mouse coordinates based in the comparison between the internal resolution and the actual window size.

For windowed mode, nothing should change, as that would always match between the sdl window and the internal resolution.

The default behavior is to stretch to fit, probably inside dxvk, which is somewhat similar to what you could see on Windows, so seems reasonable. With this, you would see a stretched image but you could see use all the controls to change the resolution or play this way.