### PR TITLE
Fix for Grouping units using LCtrl+<Number> does not work #78

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/SDL3Device/GameClient/SDL3Keyboard.cpp
@@ -90,7 +90,15 @@ static KeyDefType ConvertSDLKey(SDL_Keycode keycode)
 	}
 	else if (keycode >= SDLK_0 && keycode <= SDLK_9)
 	{
-		return (KeyDefType)(KEY_0 + (keycode - SDLK_0));
+		//SDL has 0 as first number keycode but Generals has it as last number keycode
+		if (keycode == SDLK_0)
+		{
+			return KEY_0;
+		}
+		else
+		{
+			return (KeyDefType)(KEY_1 + (keycode - SDLK_1));
+		}
 	}
 
 	switch (keycode)


### PR DESCRIPTION
Hi, I have prepared a small change that fixes #78. The problem was just that SDL orders numbers from 0 (0,1,2,...,9), but generals from 1 (1,2,3,...,9,0). So I changed the calculation to start from 1 and handled 0 as special case.