### PR TITLE
fix crash when waypoint has no links

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -577,7 +577,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 					if( m_scriptedWaypointMode )
 					{
 						Waypoint *way = TheTerrainLogic->getWaypointByID( m_nextDestWaypointID );
-						if( way )
+						if( way && way->getNumLinks() )
 						{
 							//Advance to the next waypoint.
 							Int linkCount = way->getNumLinks();


### PR DESCRIPTION
Happened when vs super weapons general in challenge mode (they were using the partical uplink cannon) 