### PR TITLE
Object vector crash fix

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3878,6 +3878,11 @@ void GameLogic::addObjectToLookupTable( Object *obj )
 	// add to lookup
 //	m_objHash[ obj->getID() ] = obj;
 	ObjectID newID = obj->getID();
+
+	if (newID == INVALID_ID) {
+		return;
+	}
+
 	while( newID >= m_objVector.size() ) // Fail case is hella rare, so faster to double up on size() call
 		m_objVector.resize(m_objVector.size() * 2, NULL);
 
@@ -3897,7 +3902,15 @@ void GameLogic::removeObjectFromLookupTable( Object *obj )
 
 	// remove from lookup table
 //	m_objHash.erase( obj->getID() );
-	m_objVector[ obj->getID() ] = NULL;
+	ObjectID id = obj->getID();
+
+	if (id == INVALID_ID) {
+		return;
+	}
+
+	if (id < m_objVector.size() && m_objVector[ id ] == obj) {
+		m_objVector[ id ] = NULL;
+	}
 
 }  // end removeObjectFromLookupTable
 


### PR DESCRIPTION
- Fix crash if obj vector is reset before all objects are removed
- Check for invalid obj id's before adding to obj vector

This happened while idling on main menu for long time then trying to start a new game, my guess the vector was cleared & resized back to default size with objects still existing with id's greater than default size